### PR TITLE
Update to Julia 1.7.0

### DIFF
--- a/include/brutus/Conversion/JLIRToLLVM/JLIRToLLVM.h
+++ b/include/brutus/Conversion/JLIRToLLVM/JLIRToLLVM.h
@@ -3,9 +3,10 @@
 
 #include "brutus/Dialect/Julia/JuliaOps.h"
 
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/include/brutus/Dialect/Julia/JuliaOps.td
+++ b/include/brutus/Dialect/Julia/JuliaOps.td
@@ -77,7 +77,7 @@ def UnimplementedOp : JLIR_Op<"unimplemented"> {
 
     let results = (outs JLIR_JuliaType:$type);
     let builders = [
-        OpBuilderDAG<(ins "jl_datatype_t *":$type)>
+        OpBuilder<(ins "jl_datatype_t *":$type)>
     ];
 }
 
@@ -89,7 +89,7 @@ def UndefOp : JLIR_Op<"undef"> {
 
     let results = (outs JLIR_JuliaType);
     let builders = [
-        OpBuilderDAG<(ins)>
+        OpBuilder<(ins)>
     ];
 }
 
@@ -102,7 +102,7 @@ def ConstantOp : JLIR_Op<"constant", [NoSideEffect]> {
     let arguments = (ins JLIR_JuliaValueAttr:$value);
     let results = (outs JLIR_JuliaType);
     let builders = [
-        OpBuilderDAG<(ins "jl_value_t *":$value, "jl_datatype_t *":$type)>
+        OpBuilder<(ins "jl_value_t *":$value, "jl_datatype_t *":$type)>
     ];
 
     // Set the folder bit so that we can implement constant folders.
@@ -123,7 +123,7 @@ def CallOp : JLIR_Op<"call"> {
     let results = (outs JLIR_JuliaType);
 
     let builders = [
-        OpBuilderDAG<(ins "Value":$callee,
+        OpBuilder<(ins "Value":$callee,
                           "ArrayRef<Value>":$arguments,
                           "jl_datatype_t *":$type)>
     ];
@@ -144,7 +144,7 @@ def InvokeOp : JLIR_Op<"invoke"> {
     let results = (outs JLIR_JuliaType);
     
     let builders = [
-        OpBuilderDAG<(ins "jl_method_instance_t *":$methodInstance, 
+        OpBuilder<(ins "jl_method_instance_t *":$methodInstance, 
                           "Value":$callee,
                           "ArrayRef<Value>":$arguments,
                           "jl_datatype_t *":$type)>
@@ -160,7 +160,7 @@ def GotoOp : JLIR_Op<"goto", [Terminator]> {
     let arguments = (ins Variadic<JLIR_JuliaType>:$operands);
     let successors = (successor AnySuccessor:$dest);
     let builders = [
-        OpBuilderDAG<(ins "Block *":$dest, "ValueRange":$operands),
+        OpBuilder<(ins "Block *":$dest, "ValueRange":$operands),
                   [{ build($_builder, $_state, operands, dest); }]>
     ];
 }
@@ -179,7 +179,7 @@ def GotoIfNotOp : JLIR_Op<"gotoifnot", [AttrSizedOperandSegments, Terminator]> {
                       AnySuccessor:$fallthroughDest);
 
     let builders = [
-        OpBuilderDAG<(ins "Value":$condition,
+        OpBuilder<(ins "Value":$condition,
                           "Block *":$branchDest, 
                           "ValueRange":$branchOperands,
                           "Block *":$fallthroughDest, 
@@ -224,7 +224,7 @@ def PiOp : JLIR_Op<"pi", [NoSideEffect]> {
     let arguments = (ins JLIR_JuliaType:$input);
     let results = (outs JLIR_JuliaType);
     let builders = [
-        OpBuilderDAG<(ins "Value":$value, "jl_datatype_t *":$type)>
+        OpBuilder<(ins "Value":$value, "jl_datatype_t *":$type)>
     ];
 }
 

--- a/include/juliapriv/julia_private.h
+++ b/include/juliapriv/julia_private.h
@@ -16,7 +16,7 @@ extern "C" {
 const char *jl_intrinsic_name(int f);
 unsigned jl_intrinsic_nargs(int f);
 
-#define jl_is_concrete_immutable(t) (jl_is_datatype(t) && (!((jl_datatype_t*)t)->mutabl) && ((jl_datatype_t*)t)->layout)
+#define jl_is_concrete_immutable(t) (jl_is_datatype(t) && (!((jl_datatype_t*)t)->name->mutabl) && ((jl_datatype_t*)t)->layout)
 
 #define JL_CALLABLE(name)                                               \
     jl_value_t *name(jl_value_t *F, jl_value_t **args, uint32_t nargs)

--- a/lib/Codegen/CMakeLists.txt
+++ b/lib/Codegen/CMakeLists.txt
@@ -8,7 +8,16 @@ add_mlir_library(
 
   LINK_LIBS PUBLIC
   MLIR
-  MLIRPublicAPI
+  MLIRCAPIDebug
+  MLIRCAPIIR
+  MLIRCAPIRegistration  # TODO: See about dis-aggregating
+
+  # Dialects
+  MLIRCAPILinalg  # TODO: Remove when above is removed.
+  MLIRCAPISparseTensor  # TODO: Remove when above is removed.
+  MLIRCAPIStandard
   MLIRExecutionEngine
+  MLIRTargetLLVMIRExport
+
 )
 llvm_update_compile_flags(BRUTUSCodegen)

--- a/lib/Codegen/Codegen.cpp
+++ b/lib/Codegen/Codegen.cpp
@@ -16,7 +16,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/Passes.h"
-#include "mlir/Target/LLVMIR.h"
+#include "mlir/Target/LLVMIR/Export.h"
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/Wrap.h"
 #include "mlir/CAPI/IR.h"
@@ -265,7 +265,7 @@ mlir::FuncOp emit_function(jl_mlirctx_t &ctx,
                 fname = "macro expansion";
             assert(inlined_at <= i);
             mlir::Location current = mlir::NameLoc::get(mlir::Identifier::get(fname, ctx.context),
-                    mlir::FileLineColLoc::get(file, line, 0, ctx.context));
+                    mlir::FileLineColLoc::get(ctx.context, file, line, 0));
 
             // codegen.cpp uses a better heuristic for now just live with this
             if (inlined_at > 0)
@@ -673,7 +673,7 @@ extern "C"
         {
             mlir::ModuleOp module = unwrap(Module);
             llvm::LLVMContext llvmContext;
-            auto Mod = mlir::translateModuleToLLVMIR(module, llvmContext);
+            auto Mod = mlir::translateModuleToLLVMIR(module, llvmContext, "JuliaModule");
             llvm::dbgs() << "after lowering to LLVM IR:";
             Mod->print(llvm::dbgs(), nullptr);
             llvm::dbgs() << "\n\n";

--- a/test/Codegen/canonicalize/branches.jl
+++ b/test/Codegen/canonicalize/branches.jl
@@ -11,7 +11,7 @@ emit(branches, Bool)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.branches), Bool}, svec(), branches(c) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/branches.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.branches), Bool}, svec(), branches(c) in Main.Main at /{{.*}}/test/Codegen/canonicalize/branches.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.branches), Bool}"(%arg0: !jlir<"typeof(Main.branches)">, %arg1: !jlir.Bool) -> !jlir.Bool attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/call_overload.jl
+++ b/test/Codegen/canonicalize/call_overload.jl
@@ -9,7 +9,7 @@ emit(a, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{Main.Main.A, Int64}, svec(), (a::Main.Main.A)(y) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/call_overload.jl:6, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{Main.Main.A, Int64}, svec(), (a::Main.Main.A)(y) in Main.Main at /{{.*}}/test/Codegen/canonicalize/call_overload.jl:6, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{Main.A, Int64}"(%arg0: !jlir.Main.A, %arg1: !jlir.Int64) -> !jlir.Any attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/calls.jl
+++ b/test/Codegen/canonicalize/calls.jl
@@ -10,7 +10,7 @@ emit(calls)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.calls)}, svec(), calls() in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/calls.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.calls)}, svec(), calls() in Main.Main at /{{.*}}/test/Codegen/canonicalize/calls.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.calls)}"(%arg0: !jlir<"typeof(Main.calls)">) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/haspi.jl
+++ b/test/Codegen/canonicalize/haspi.jl
@@ -9,7 +9,7 @@ emit(haspi, Union{Int64, Float64})
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.haspi), Union{Float64, Int64}}, svec(), haspi(x::Union{Float64, Int64}) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/haspi.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.haspi), Union{Float64, Int64}}, svec(), haspi(x::Union{Float64, Int64}) in Main.Main at /{{.*}}/test/Codegen/canonicalize/haspi.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.haspi), Union{Float64, Int64}}"(%arg0: !jlir<"typeof(Main.haspi)">, %arg1: !jlir<"Union{Float64, Int64}">) -> !jlir<"Union{Nothing, Int64}"> attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/identity.jl
+++ b/test/Codegen/canonicalize/identity.jl
@@ -5,7 +5,7 @@ emit(f, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f), Int64}, svec(), f(x) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/identity.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f), Int64}, svec(), f(x) in Main.Main at /{{.*}}/test/Codegen/canonicalize/identity.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.f), Int64}"(%arg0: !jlir<"typeof(Main.f)">, %arg1: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/labels.jl
+++ b/test/Codegen/canonicalize/labels.jl
@@ -21,7 +21,7 @@ emit(labels, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.labels), Int64}, svec(), labels(N) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/labels.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.labels), Int64}, svec(), labels(N) in Main.Main at /{{.*}}/test/Codegen/canonicalize/labels.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.labels), Int64}"(%arg0: !jlir<"typeof(Main.labels)">, %arg1: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/loop.jl
+++ b/test/Codegen/canonicalize/loop.jl
@@ -11,7 +11,7 @@ emit(loop, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.loop), Int64}, svec(), loop(N) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/loop.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.loop), Int64}, svec(), loop(N) in Main.Main at /{{.*}}/test/Codegen/canonicalize/loop.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.loop), Int64}"(%arg0: !jlir<"typeof(Main.loop)">, %arg1: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/matmul.jl
+++ b/test/Codegen/canonicalize/matmul.jl
@@ -16,7 +16,7 @@ emit(matmul!, Matrix{Float64}, Matrix{Float64}, Matrix{Float64})
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.matmul!), Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}, svec(), matmul!(C, A, B) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/matmul.jl:4, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.matmul!), Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}, svec(), matmul!(C, A, B) in Main.Main at /{{.*}}/test/Codegen/canonicalize/matmul.jl:4, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.matmul!), Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}"(%arg0: !jlir<"typeof(Main.matmul!)">, %arg1: !jlir<"Array{Float64, 2}">, %arg2: !jlir<"Array{Float64, 2}">, %arg3: !jlir<"Array{Float64, 2}">) -> !jlir.Nothing attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/return_const.jl
+++ b/test/Codegen/canonicalize/return_const.jl
@@ -5,7 +5,7 @@ emit(f)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f)}, svec(), f() in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/return_const.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f)}, svec(), f() in Main.Main at /{{.*}}/test/Codegen/canonicalize/return_const.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.f)}"(%arg0: !jlir<"typeof(Main.f)">) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/return_nothing.jl
+++ b/test/Codegen/canonicalize/return_nothing.jl
@@ -5,7 +5,7 @@ emit(f)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f)}, svec(), f() in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/return_nothing.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f)}, svec(), f() in Main.Main at /{{.*}}/test/Codegen/canonicalize/return_nothing.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.f)}"(%arg0: !jlir<"typeof(Main.f)">) -> !jlir.Nothing attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/sum.jl
+++ b/test/Codegen/canonicalize/sum.jl
@@ -12,7 +12,7 @@ emit(sum, Matrix{Float64})
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.sum), Matrix{Float64}}, svec(), sum(A) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/canonicalize/sum.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.sum), Matrix{Float64}}, svec(), sum(A) in Main.Main at /{{.*}}/test/Codegen/canonicalize/sum.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.sum), Array{Float64, 2}}"(%arg0: !jlir<"typeof(Main.sum)">, %arg1: !jlir<"Array{Float64, 2}">) -> !jlir.Float64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/canonicalize/sum.jl
+++ b/test/Codegen/canonicalize/sum.jl
@@ -11,7 +11,6 @@ end
 emit(sum, Matrix{Float64})
 
 
-
 # CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.sum), Matrix{Float64}}, svec(), sum(A) in Main.Main at /{{.*}}/test/Codegen/canonicalize/sum.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.sum), Array{Float64, 2}}"(%arg0: !jlir<"typeof(Main.sum)">, %arg1: !jlir<"Array{Float64, 2}">) -> !jlir.Float64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()

--- a/test/Codegen/lower/add_float64.jl
+++ b/test/Codegen/lower/add_float64.jl
@@ -6,7 +6,7 @@ emit(add, Float64, Float64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.add), Float64, Float64}, svec(), add(x, y) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/add_float64.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.add), Float64, Float64}, svec(), add(x, y) in Main.Main at /{{.*}}/test/Codegen/lower/add_float64.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.add), Float64, Float64}"(%arg0: !jlir<"typeof(Main.add)">, %arg1: !jlir.Float64, %arg2: !jlir.Float64) -> !jlir.Float64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/add_int.jl
+++ b/test/Codegen/lower/add_int.jl
@@ -6,7 +6,7 @@ emit(add, Int64, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.add), Int64, Int64}, svec(), add(x, y) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/add_int.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.add), Int64, Int64}, svec(), add(x, y) in Main.Main at /{{.*}}/test/Codegen/lower/add_int.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.add), Int64, Int64}"(%arg0: !jlir<"typeof(Main.add)">, %arg1: !jlir.Int64, %arg2: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/gauss.jl
+++ b/test/Codegen/lower/gauss.jl
@@ -12,7 +12,7 @@ emit(gauss, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.gauss), Int64}, svec(), gauss(N) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/gauss.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.gauss), Int64}, svec(), gauss(N) in Main.Main at /{{.*}}/test/Codegen/lower/gauss.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.gauss), Int64}"(%arg0: !jlir<"typeof(Main.gauss)">, %arg1: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/index_3D.jl
+++ b/test/Codegen/lower/index_3D.jl
@@ -7,7 +7,7 @@ emit(index, Array{Int64, 3}, Int64, Int64, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.index), Array{Int64, 3}, Int64, Int64, Int64}, svec(), index(A, i, j, k) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/index_3D.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.index), Array{Int64, 3}, Int64, Int64, Int64}, svec(), index(A, i, j, k) in Main.Main at /{{.*}}/test/Codegen/lower/index_3D.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.index), Array{Int64, 3}, Int64, Int64, Int64}"(%arg0: !jlir<"typeof(Main.index)">, %arg1: !jlir<"Array{Int64, 3}">, %arg2: !jlir.Int64, %arg3: !jlir.Int64, %arg4: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/index_linear_1D.jl
+++ b/test/Codegen/lower/index_linear_1D.jl
@@ -7,7 +7,7 @@ emit(index, Array{Int64, 1}, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.index), Vector{Int64}, Int64}, svec(), index(A, i) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/index_linear_1D.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.index), Vector{Int64}, Int64}, svec(), index(A, i) in Main.Main at /{{.*}}/test/Codegen/lower/index_linear_1D.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.index), Array{Int64, 1}, Int64}"(%arg0: !jlir<"typeof(Main.index)">, %arg1: !jlir<"Array{Int64, 1}">, %arg2: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/index_linear_3D.jl
+++ b/test/Codegen/lower/index_linear_3D.jl
@@ -7,7 +7,7 @@ emit(index, Array{Int64, 3}, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.index), Array{Int64, 3}, Int64}, svec(), index(A, i) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/index_linear_3D.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.index), Array{Int64, 3}, Int64}, svec(), index(A, i) in Main.Main at /{{.*}}/test/Codegen/lower/index_linear_3D.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.index), Array{Int64, 3}, Int64}"(%arg0: !jlir<"typeof(Main.index)">, %arg1: !jlir<"Array{Int64, 3}">, %arg2: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/matmul.jl
+++ b/test/Codegen/lower/matmul.jl
@@ -17,7 +17,7 @@ emit(matmul!, Matrix{Float64}, Matrix{Float64}, Matrix{Float64})
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.matmul!), Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}, svec(), matmul!(C, A, B) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/matmul.jl:4, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.matmul!), Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}, svec(), matmul!(C, A, B) in Main.Main at /{{.*}}/test/Codegen/lower/matmul.jl:4, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.matmul!), Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}"(%arg0: !jlir<"typeof(Main.matmul!)">, %arg1: !jlir<"Array{Float64, 2}">, %arg2: !jlir<"Array{Float64, 2}">, %arg3: !jlir<"Array{Float64, 2}">) -> !jlir.Nothing attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/ne.jl
+++ b/test/Codegen/lower/ne.jl
@@ -6,7 +6,7 @@ emit(ne, Float64, Float64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.ne), Float64, Float64}, svec(), ne(x, y) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/ne.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.ne), Float64, Float64}, svec(), ne(x, y) in Main.Main at /{{.*}}/test/Codegen/lower/ne.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.ne), Float64, Float64}"(%arg0: !jlir<"typeof(Main.ne)">, %arg1: !jlir.Float64, %arg2: !jlir.Float64) -> !jlir.Bool attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/select.jl
+++ b/test/Codegen/lower/select.jl
@@ -6,7 +6,7 @@ emit(select, Bool)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.select), Bool}, svec(), select(c) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/select.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.select), Bool}, svec(), select(c) in Main.Main at /{{.*}}/test/Codegen/lower/select.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.select), Bool}"(%arg0: !jlir<"typeof(Main.select)">, %arg1: !jlir.Bool) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/sle.jl
+++ b/test/Codegen/lower/sle.jl
@@ -6,7 +6,7 @@ emit(sle_int, Int64, Int64)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.sle_int), Int64, Int64}, svec(), sle_int(x, y) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/sle.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.sle_int), Int64, Int64}, svec(), sle_int(x, y) in Main.Main at /{{.*}}/test/Codegen/lower/sle.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.sle_int), Int64, Int64}"(%arg0: !jlir<"typeof(Main.sle_int)">, %arg1: !jlir.Int64, %arg2: !jlir.Int64) -> !jlir.Bool attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/lower/symbol.jl
+++ b/test/Codegen/lower/symbol.jl
@@ -6,7 +6,7 @@ emit(symbol)
 
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.symbol)}, svec(), symbol() in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/lower/symbol.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.symbol)}, svec(), symbol() in Main.Main at /{{.*}}/test/Codegen/lower/symbol.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.symbol)}"(%arg0: !jlir<"typeof(Main.symbol)">) -> !jlir.Symbol attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/branches..jl
+++ b/test/Codegen/translate/branches..jl
@@ -10,7 +10,7 @@ end
 emit(branches, Bool)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.branches), Bool}, svec(), branches(c) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/branches..jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.branches), Bool}, svec(), branches(c) in Main.Main at /{{.*}}/test/Codegen/translate/branches..jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.branches), Bool}"(%arg0: !jlir<"typeof(Main.branches)">, %arg1: !jlir.Bool) -> !jlir.Bool attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/call_overload.jl
+++ b/test/Codegen/translate/call_overload.jl
@@ -8,7 +8,7 @@ a = A(10)
 emit(a, Int64)
 
 
-# CHECK: Core.MethodMatch(Tuple{Main.Main.A, Int64}, svec(), (a::Main.Main.A)(y) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/call_overload.jl:6, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{Main.Main.A, Int64}, svec(), (a::Main.Main.A)(y) in Main.Main at /{{.*}}/test/Codegen/translate/call_overload.jl:6, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{Main.A, Int64}"(%arg0: !jlir.Main.A, %arg1: !jlir.Int64) -> !jlir.Any attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/caller.jl
+++ b/test/Codegen/translate/caller.jl
@@ -7,7 +7,7 @@ end
 emit(caller, Int64, Int64)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.caller), Int64, Int64}, svec(), caller(x, y) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/caller.jl:4, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.caller), Int64, Int64}, svec(), caller(x, y) in Main.Main at /{{.*}}/test/Codegen/translate/caller.jl:4, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.caller), Int64, Int64}"(%arg0: !jlir<"typeof(Main.caller)">, %arg1: !jlir.Int64, %arg2: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/calls.jl
+++ b/test/Codegen/translate/calls.jl
@@ -7,7 +7,7 @@ end
 emit(calls)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.calls)}, svec(), calls() in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/calls.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.calls)}, svec(), calls() in Main.Main at /{{.*}}/test/Codegen/translate/calls.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.calls)}"(%arg0: !jlir<"typeof(Main.calls)">) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/haspi.jl
+++ b/test/Codegen/translate/haspi.jl
@@ -8,7 +8,7 @@ end
 emit(haspi, Union{Int64, Float64})
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.haspi), Union{Float64, Int64}}, svec(), haspi(x::Union{Float64, Int64}) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/haspi.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.haspi), Union{Float64, Int64}}, svec(), haspi(x::Union{Float64, Int64}) in Main.Main at /{{.*}}/test/Codegen/translate/haspi.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.haspi), Union{Float64, Int64}}"(%arg0: !jlir<"typeof(Main.haspi)">, %arg1: !jlir<"Union{Float64, Int64}">) -> !jlir<"Union{Nothing, Int64}"> attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/hasunreachable.jl
+++ b/test/Codegen/translate/hasunreachable.jl
@@ -5,7 +5,7 @@ hasunreachable(x::Float64) = sqrt(x)
 emit(hasunreachable, Float64)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.hasunreachable), Float64}, svec(), hasunreachable(x::Float64) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/hasunreachable.jl:4, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.hasunreachable), Float64}, svec(), hasunreachable(x::Float64) in Main.Main at /{{.*}}/test/Codegen/translate/hasunreachable.jl:4, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.hasunreachable), Float64}"(%arg0: !jlir<"typeof(Main.hasunreachable)">, %arg1: !jlir.Float64) -> !jlir.Float64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/identity.jl
+++ b/test/Codegen/translate/identity.jl
@@ -4,7 +4,7 @@ f(x) = x
 emit(f, Int64)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f), Int64}, svec(), f(x) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/identity.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f), Int64}, svec(), f(x) in Main.Main at /{{.*}}/test/Codegen/translate/identity.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.f), Int64}"(%arg0: !jlir<"typeof(Main.f)">, %arg1: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/labels.jl
+++ b/test/Codegen/translate/labels.jl
@@ -20,7 +20,7 @@ end
 emit(labels, Int64)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.labels), Int64}, svec(), labels(N) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/labels.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.labels), Int64}, svec(), labels(N) in Main.Main at /{{.*}}/test/Codegen/translate/labels.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.labels), Int64}"(%arg0: !jlir<"typeof(Main.labels)">, %arg1: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/loop.jl
+++ b/test/Codegen/translate/loop.jl
@@ -10,7 +10,7 @@ end
 emit(loop, Int64)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.loop), Int64}, svec(), loop(N) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/loop.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.loop), Int64}, svec(), loop(N) in Main.Main at /{{.*}}/test/Codegen/translate/loop.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.loop), Int64}"(%arg0: !jlir<"typeof(Main.loop)">, %arg1: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/loop.jl
+++ b/test/Codegen/translate/loop.jl
@@ -9,61 +9,62 @@ function loop(N)
 end
 emit(loop, Int64)
 
-
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.loop), Int64}, svec(), loop(N) in Main.Main at /{{.*}}/test/Codegen/translate/loop.jl:3, true)after translating to MLIR in JLIR dialect:module  {
-# CHECK-NEXT:   func nested @"Tuple{typeof(Main.loop), Int64}"(%arg0: !jlir<"typeof(Main.loop)">, %arg1: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
-# CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
-# CHECK-NEXT:   ^bb1:  // pred: ^bb0
-# CHECK-NEXT:     %0 = "jlir.constant"() {value = #jlir<"#<intrinsic #29 sle_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
-# CHECK-NEXT:     %1 = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
-# CHECK-NEXT:     %2 = "jlir.call"(%0, %1, %arg1) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Int64, !jlir.Int64) -> !jlir.Bool
-# CHECK-NEXT:     %3 = "jlir.constant"() {value = #jlir.ifelse} : () -> !jlir<"typeof(ifelse)">
-# CHECK-NEXT:     %4 = "jlir.constant"() {value = #jlir<"0">} : () -> !jlir.Int64
-# CHECK-NEXT:     %5 = "jlir.call"(%3, %2, %arg1, %4) : (!jlir<"typeof(ifelse)">, !jlir.Bool, !jlir.Int64, !jlir.Int64) -> !jlir.Int64
-# CHECK-NEXT:     %6 = "jlir.constant"() {value = #jlir<"#<intrinsic #27 slt_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
-# CHECK-NEXT:     %7 = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
-# CHECK-NEXT:     %8 = "jlir.call"(%6, %5, %7) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Int64, !jlir.Int64) -> !jlir.Bool
-# CHECK-NEXT:     "jlir.gotoifnot"(%8)[^bb3, ^bb2] {operand_segment_sizes = dense<[1, 0, 0]> : vector<3xi32>} : (!jlir.Bool) -> ()
-# CHECK-NEXT:   ^bb2:  // pred: ^bb1
-# CHECK-NEXT:     %9 = "jlir.constant"() {value = #jlir.true} : () -> !jlir.Bool
-# CHECK-NEXT:     %10 = "jlir.undef"() : () -> !jlir.Int64
-# CHECK-NEXT:     %11 = "jlir.undef"() : () -> !jlir.Int64
-# CHECK-NEXT:     "jlir.goto"(%9, %10, %11)[^bb4] : (!jlir.Bool, !jlir.Int64, !jlir.Int64) -> ()
-# CHECK-NEXT:   ^bb3:  // pred: ^bb1
-# CHECK-NEXT:     %12 = "jlir.constant"() {value = #jlir.false} : () -> !jlir.Bool
-# CHECK-NEXT:     %13 = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
-# CHECK-NEXT:     %14 = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
-# CHECK-NEXT:     "jlir.goto"(%12, %13, %14)[^bb4] : (!jlir.Bool, !jlir.Int64, !jlir.Int64) -> ()
-# CHECK-NEXT:   ^bb4(%15: !jlir.Bool, %16: !jlir.Int64, %17: !jlir.Int64):  // 2 preds: ^bb2, ^bb3
-# CHECK-NEXT:     %18 = "jlir.constant"() {value = #jlir<"#<intrinsic #44 not_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
-# CHECK-NEXT:     %19 = "jlir.call"(%18, %15) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Bool) -> !jlir.Bool
-# CHECK-NEXT:     %20 = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
-# CHECK-NEXT:     %21 = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
-# CHECK-NEXT:     "jlir.gotoifnot"(%19, %21, %16, %17, %20)[^bb10, ^bb5] {operand_segment_sizes = dense<[1, 1, 3]> : vector<3xi32>} : (!jlir.Bool, !jlir.Int64, !jlir.Int64, !jlir.Int64, !jlir.Int64) -> ()
-# CHECK-NEXT:   ^bb5(%22: !jlir.Int64, %23: !jlir.Int64, %24: !jlir.Int64):  // 2 preds: ^bb4, ^bb9
-# CHECK-NEXT:     %25 = "jlir.constant"() {value = #jlir<"#<intrinsic #2 add_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
-# CHECK-NEXT:     %26 = "jlir.call"(%25, %24, %22) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Int64, !jlir.Int64) -> !jlir.Int64
-# CHECK-NEXT:     %27 = "jlir.constant"() {value = #jlir<"===">} : () -> !jlir<"typeof(===)">
-# CHECK-NEXT:     %28 = "jlir.call"(%27, %23, %5) : (!jlir<"typeof(===)">, !jlir.Int64, !jlir.Int64) -> !jlir.Bool
-# CHECK-NEXT:     "jlir.gotoifnot"(%28)[^bb7, ^bb6] {operand_segment_sizes = dense<[1, 0, 0]> : vector<3xi32>} : (!jlir.Bool) -> ()
-# CHECK-NEXT:   ^bb6:  // pred: ^bb5
-# CHECK-NEXT:     %29 = "jlir.undef"() : () -> !jlir.Int64
-# CHECK-NEXT:     %30 = "jlir.undef"() : () -> !jlir.Int64
-# CHECK-NEXT:     %31 = "jlir.constant"() {value = #jlir.true} : () -> !jlir.Bool
-# CHECK-NEXT:     "jlir.goto"(%29, %30, %31)[^bb8] : (!jlir.Int64, !jlir.Int64, !jlir.Bool) -> ()
-# CHECK-NEXT:   ^bb7:  // pred: ^bb5
-# CHECK-NEXT:     %32 = "jlir.constant"() {value = #jlir<"#<intrinsic #2 add_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
-# CHECK-NEXT:     %33 = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
-# CHECK-NEXT:     %34 = "jlir.call"(%32, %23, %33) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Int64, !jlir.Int64) -> !jlir.Int64
-# CHECK-NEXT:     %35 = "jlir.constant"() {value = #jlir.false} : () -> !jlir.Bool
-# CHECK-NEXT:     "jlir.goto"(%34, %34, %35)[^bb8] : (!jlir.Int64, !jlir.Int64, !jlir.Bool) -> ()
-# CHECK-NEXT:   ^bb8(%36: !jlir.Int64, %37: !jlir.Int64, %38: !jlir.Bool):  // 2 preds: ^bb6, ^bb7
-# CHECK-NEXT:     %39 = "jlir.constant"() {value = #jlir<"#<intrinsic #44 not_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
-# CHECK-NEXT:     %40 = "jlir.call"(%39, %38) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Bool) -> !jlir.Bool
-# CHECK-NEXT:     "jlir.gotoifnot"(%40, %26)[^bb10, ^bb9] {operand_segment_sizes = dense<[1, 1, 0]> : vector<3xi32>} : (!jlir.Bool, !jlir.Int64) -> ()
-# CHECK-NEXT:   ^bb9:  // pred: ^bb8
-# CHECK-NEXT:     "jlir.goto"(%36, %37, %26)[^bb5] : (!jlir.Int64, !jlir.Int64, !jlir.Int64) -> ()
-# CHECK-NEXT:   ^bb10(%41: !jlir.Int64):  // 2 preds: ^bb4, ^bb8
-# CHECK-NEXT:     "jlir.return"(%41) : (!jlir.Int64) -> ()
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
+# CHECK-LABEL:   func nested @"Tuple{typeof(Main.loop), Int64}"(
+# CHECK-SAME:                                                   %[[VAL_0:.*]]: !jlir<"typeof(Main.loop)">,
+# CHECK-SAME:                                                   %[[VAL_1:.*]]: !jlir.Int64) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
+# CHECK:           "jlir.goto"()[^bb1] : () -> ()
+# CHECK:         ^bb1:
+# CHECK:           %[[VAL_2:.*]] = "jlir.constant"() {value = #jlir<"#<intrinsic #29 sle_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
+# CHECK:           %[[VAL_3:.*]] = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
+# CHECK:           %[[VAL_4:.*]] = "jlir.call"(%[[VAL_2]], %[[VAL_3]], %[[VAL_1]]) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Int64, !jlir.Int64) -> !jlir.Bool
+# CHECK:           %[[VAL_5:.*]] = "jlir.constant"() {value = #jlir.ifelse} : () -> !jlir<"typeof(ifelse)">
+# CHECK:           %[[VAL_6:.*]] = "jlir.constant"() {value = #jlir<"0">} : () -> !jlir.Int64
+# CHECK:           %[[VAL_7:.*]] = "jlir.call"(%[[VAL_5]], %[[VAL_4]], %[[VAL_1]], %[[VAL_6]]) : (!jlir<"typeof(ifelse)">, !jlir.Bool, !jlir.Int64, !jlir.Int64) -> !jlir.Int64
+# CHECK:           %[[VAL_8:.*]] = "jlir.constant"() {value = #jlir<"#<intrinsic #27 slt_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
+# CHECK:           %[[VAL_9:.*]] = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
+# CHECK:           %[[VAL_10:.*]] = "jlir.call"(%[[VAL_8]], %[[VAL_7]], %[[VAL_9]]) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Int64, !jlir.Int64) -> !jlir.Bool
+# CHECK:           "jlir.gotoifnot"(%[[VAL_10]])[^bb3, ^bb2] {operand_segment_sizes = dense<[1, 0, 0]> : vector<3xi32>} : (!jlir.Bool) -> ()
+# CHECK:         ^bb2:
+# CHECK:           %[[VAL_11:.*]] = "jlir.constant"() {value = #jlir.nothing} : () -> !jlir.Nothing
+# CHECK:           %[[VAL_12:.*]] = "jlir.constant"() {value = #jlir.true} : () -> !jlir.Bool
+# CHECK:           %[[VAL_13:.*]] = "jlir.undef"() : () -> !jlir.Int64
+# CHECK:           %[[VAL_14:.*]] = "jlir.undef"() : () -> !jlir.Int64
+# CHECK:           "jlir.goto"(%[[VAL_12]], %[[VAL_13]], %[[VAL_14]])[^bb4] : (!jlir.Bool, !jlir.Int64, !jlir.Int64) -> ()
+# CHECK:         ^bb3:
+# CHECK:           %[[VAL_15:.*]] = "jlir.constant"() {value = #jlir.false} : () -> !jlir.Bool
+# CHECK:           %[[VAL_16:.*]] = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
+# CHECK:           %[[VAL_17:.*]] = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
+# CHECK:           "jlir.goto"(%[[VAL_15]], %[[VAL_16]], %[[VAL_17]])[^bb4] : (!jlir.Bool, !jlir.Int64, !jlir.Int64) -> ()
+# CHECK:         ^bb4(%[[VAL_18:.*]]: !jlir.Bool, %[[VAL_19:.*]]: !jlir.Int64, %[[VAL_20:.*]]: !jlir.Int64):
+# CHECK:           %[[VAL_21:.*]] = "jlir.constant"() {value = #jlir<"#<intrinsic #43 not_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
+# CHECK:           %[[VAL_22:.*]] = "jlir.call"(%[[VAL_21]], %[[VAL_18]]) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Bool) -> !jlir.Bool
+# CHECK:           %[[VAL_23:.*]] = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
+# CHECK:           %[[VAL_24:.*]] = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
+# CHECK:           "jlir.gotoifnot"(%[[VAL_22]], %[[VAL_24]], %[[VAL_19]], %[[VAL_20]], %[[VAL_23]])[^bb10, ^bb5] {operand_segment_sizes = dense<[1, 1, 3]> : vector<3xi32>} : (!jlir.Bool, !jlir.Int64, !jlir.Int64, !jlir.Int64, !jlir.Int64) -> ()
+# CHECK:         ^bb5(%[[VAL_25:.*]]: !jlir.Int64, %[[VAL_26:.*]]: !jlir.Int64, %[[VAL_27:.*]]: !jlir.Int64):
+# CHECK:           %[[VAL_28:.*]] = "jlir.constant"() {value = #jlir<"#<intrinsic #2 add_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
+# CHECK:           %[[VAL_29:.*]] = "jlir.call"(%[[VAL_28]], %[[VAL_27]], %[[VAL_25]]) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Int64, !jlir.Int64) -> !jlir.Int64
+# CHECK:           %[[VAL_30:.*]] = "jlir.constant"() {value = #jlir<"===">} : () -> !jlir<"typeof(===)">
+# CHECK:           %[[VAL_31:.*]] = "jlir.call"(%[[VAL_30]], %[[VAL_26]], %[[VAL_7]]) : (!jlir<"typeof(===)">, !jlir.Int64, !jlir.Int64) -> !jlir.Bool
+# CHECK:           "jlir.gotoifnot"(%[[VAL_31]])[^bb7, ^bb6] {operand_segment_sizes = dense<[1, 0, 0]> : vector<3xi32>} : (!jlir.Bool) -> ()
+# CHECK:         ^bb6:
+# CHECK:           %[[VAL_32:.*]] = "jlir.constant"() {value = #jlir.nothing} : () -> !jlir.Nothing
+# CHECK:           %[[VAL_33:.*]] = "jlir.undef"() : () -> !jlir.Int64
+# CHECK:           %[[VAL_34:.*]] = "jlir.undef"() : () -> !jlir.Int64
+# CHECK:           %[[VAL_35:.*]] = "jlir.constant"() {value = #jlir.true} : () -> !jlir.Bool
+# CHECK:           "jlir.goto"(%[[VAL_33]], %[[VAL_34]], %[[VAL_35]])[^bb8] : (!jlir.Int64, !jlir.Int64, !jlir.Bool) -> ()
+# CHECK:         ^bb7:
+# CHECK:           %[[VAL_36:.*]] = "jlir.constant"() {value = #jlir<"#<intrinsic #2 add_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
+# CHECK:           %[[VAL_37:.*]] = "jlir.constant"() {value = #jlir<"1">} : () -> !jlir.Int64
+# CHECK:           %[[VAL_38:.*]] = "jlir.call"(%[[VAL_36]], %[[VAL_26]], %[[VAL_37]]) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Int64, !jlir.Int64) -> !jlir.Int64
+# CHECK:           %[[VAL_39:.*]] = "jlir.constant"() {value = #jlir.false} : () -> !jlir.Bool
+# CHECK:           "jlir.goto"(%[[VAL_38]], %[[VAL_38]], %[[VAL_39]])[^bb8] : (!jlir.Int64, !jlir.Int64, !jlir.Bool) -> ()
+# CHECK:         ^bb8(%[[VAL_40:.*]]: !jlir.Int64, %[[VAL_41:.*]]: !jlir.Int64, %[[VAL_42:.*]]: !jlir.Bool):
+# CHECK:           %[[VAL_43:.*]] = "jlir.constant"() {value = #jlir<"#<intrinsic #43 not_int>">} : () -> !jlir<"typeof(Core.IntrinsicFunction)">
+# CHECK:           %[[VAL_44:.*]] = "jlir.call"(%[[VAL_43]], %[[VAL_42]]) : (!jlir<"typeof(Core.IntrinsicFunction)">, !jlir.Bool) -> !jlir.Bool
+# CHECK:           "jlir.gotoifnot"(%[[VAL_44]], %[[VAL_29]])[^bb10, ^bb9] {operand_segment_sizes = dense<[1, 1, 0]> : vector<3xi32>} : (!jlir.Bool, !jlir.Int64) -> ()
+# CHECK:         ^bb9:
+# CHECK:           "jlir.goto"(%[[VAL_40]], %[[VAL_41]], %[[VAL_29]])[^bb5] : (!jlir.Int64, !jlir.Int64, !jlir.Int64) -> ()
+# CHECK:         ^bb10(%[[VAL_45:.*]]: !jlir.Int64):
+# CHECK:           "jlir.return"(%[[VAL_45]]) : (!jlir.Int64) -> ()
+# CHECK:         }

--- a/test/Codegen/translate/matmul.jl
+++ b/test/Codegen/translate/matmul.jl
@@ -15,7 +15,7 @@ end
 emit(matmul!, Matrix{Float64}, Matrix{Float64}, Matrix{Float64})
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.matmul!), Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}, svec(), matmul!(C, A, B) in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/matmul.jl:4, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.matmul!), Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}, svec(), matmul!(C, A, B) in Main.Main at /{{.*}}/test/Codegen/translate/matmul.jl:4, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.matmul!), Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}"(%arg0: !jlir<"typeof(Main.matmul!)">, %arg1: !jlir<"Array{Float64, 2}">, %arg2: !jlir<"Array{Float64, 2}">, %arg3: !jlir<"Array{Float64, 2}">) -> !jlir.Nothing attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/return_const.jl
+++ b/test/Codegen/translate/return_const.jl
@@ -4,7 +4,7 @@ f() = return 2
 emit(f)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f)}, svec(), f() in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/return_const.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f)}, svec(), f() in Main.Main at /{{.*}}/test/Codegen/translate/return_const.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.f)}"(%arg0: !jlir<"typeof(Main.f)">) -> !jlir.Int64 attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0

--- a/test/Codegen/translate/return_nothing.jl
+++ b/test/Codegen/translate/return_nothing.jl
@@ -4,7 +4,7 @@ f() = return
 emit(f)
 
 
-# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f)}, svec(), f() in Main.Main at /home/mccoy/Dev/brutus/test/Codegen/translate/return_nothing.jl:3, true)after translating to MLIR in JLIR dialect:module  {
+# CHECK: Core.MethodMatch(Tuple{typeof(Main.Main.f)}, svec(), f() in Main.Main at /{{.*}}/test/Codegen/translate/return_nothing.jl:3, true)after translating to MLIR in JLIR dialect:module  {
 # CHECK-NEXT:   func nested @"Tuple{typeof(Main.f)}"(%arg0: !jlir<"typeof(Main.f)">) -> !jlir.Nothing attributes {llvm.emit_c_interface} {
 # CHECK-NEXT:     "jlir.goto"()[^bb1] : () -> ()
 # CHECK-NEXT:   ^bb1:  // pred: ^bb0


### PR DESCRIPTION
This gets the CPP to compile, but then check-brutus still fails:

Precompiling project...
  ✓ Zlib_jll
  ✓ MbedTLS_jll
  ✓ CEnum
  ✓ ExprTools
  ✓ Preferences
  ✓ LibSSH2_jll
  ✓ JLLWrappers
  ✓ TimerOutputs
  ✓ LLVMExtra_jll
  ✗ LLVM
  ✗ GPUCompiler
  ✗ Brutus
  9 dependencies successfully precompiled in 8 seconds

ERROR: The following 2 direct dependencies failed to precompile:

GPUCompiler [61eb1bfa-7361-4325-ad38-22787b887f55]

Failed to precompile GPUCompiler [61eb1bfa-7361-4325-ad38-22787b887f55] to /home/stephenn/.julia/compiled/v1.7/GPUCompiler/jl_eSV5S2.
ERROR: LoadError: InitError: could not load library "/home/stephenn/.julia/artifacts/f1d0060dd1a7698898f46626e143e03a442af46f/lib/libLLVMExtra-12.so"
/wrk/xsjhdnobkup2/stephenn/brutus/julia/usr/bin/../lib/libLLVM-12jl.so: version `JL_LLVM_12.0' not found (required by /home/stephenn/.julia/artifacts/f1d0060dd1a7698898f46626e143e03a442af46f/lib/libLLVMExtra-12.so)